### PR TITLE
[feat] activity_main / BottomNavigation과 ViewPager 연동 (#29)

### DIFF
--- a/app/src/main/java/com/readme/android/MainActivity.kt
+++ b/app/src/main/java/com/readme/android/MainActivity.kt
@@ -31,10 +31,9 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         })
 
         binding.bottomNav.setOnItemSelectedListener {
-            binding.vpMain.currentItem = when (it.itemId) {
-                R.id.menu_home -> 0
-                R.id.menu_my_page -> 1
-                else -> return@setOnItemSelectedListener false
+            when (it.itemId) {
+                R.id.menu_home -> binding.vpMain.setCurrentItem(0, false)
+                R.id.menu_my_page -> binding.vpMain.setCurrentItem(1, false)
             }
             return@setOnItemSelectedListener true
         }

--- a/app/src/main/java/com/readme/android/MainActivity.kt
+++ b/app/src/main/java/com/readme/android/MainActivity.kt
@@ -1,11 +1,23 @@
 package com.readme.android
 
 import android.os.Bundle
+import com.readme.android.adapter.MainViewPagerAdapter
 import com.readme.android.core.base.BindingActivity
 import com.readme.android.databinding.ActivityMainBinding
+import com.readme.android.main.ui.home.HomeFragment
+import com.readme.android.main.ui.mypage.MyPageFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
+    private lateinit var mainViewPagerAdapter: MainViewPagerAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        initAdapter()
+    }
+
+    private fun initAdapter() {
+        binding.vpMain.adapter = MainViewPagerAdapter(this).also { mainViewPagerAdapter = it }
+        mainViewPagerAdapter.fragments.addAll(listOf(HomeFragment(), MyPageFragment()))
     }
 }

--- a/app/src/main/java/com/readme/android/MainActivity.kt
+++ b/app/src/main/java/com/readme/android/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initAdapter()
-        syncVpWithBottomNav()
+        syncBottomNavWithVp()
     }
 
     private fun initAdapter() {
@@ -22,7 +22,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         mainViewPagerAdapter.fragments.addAll(listOf(HomeFragment(), MyPageFragment()))
     }
 
-    private fun syncVpWithBottomNav() {
+    private fun syncBottomNavWithVp() {
         binding.vpMain.isUserInputEnabled = false
 
         binding.bottomNav.setOnItemSelectedListener {

--- a/app/src/main/java/com/readme/android/MainActivity.kt
+++ b/app/src/main/java/com/readme/android/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private fun initAdapter() {
         binding.vpMain.adapter = MainViewPagerAdapter(this).also { mainViewPagerAdapter = it }
-        mainViewPagerAdapter.fragments.addAll(listOf(HomeFragment(), MyPageFragment()))
+        mainViewPagerAdapter.fragmentList = listOf(HomeFragment(), MyPageFragment())
     }
 
     private fun syncBottomNavWithVp() {

--- a/app/src/main/java/com/readme/android/MainActivity.kt
+++ b/app/src/main/java/com/readme/android/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.readme.android
 
 import android.os.Bundle
+import androidx.viewpager2.widget.ViewPager2
 import com.readme.android.adapter.MainViewPagerAdapter
 import com.readme.android.core.base.BindingActivity
 import com.readme.android.databinding.ActivityMainBinding
@@ -14,10 +15,28 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initAdapter()
+        syncVpWithBottomNav()
     }
 
     private fun initAdapter() {
         binding.vpMain.adapter = MainViewPagerAdapter(this).also { mainViewPagerAdapter = it }
         mainViewPagerAdapter.fragments.addAll(listOf(HomeFragment(), MyPageFragment()))
+    }
+
+    private fun syncVpWithBottomNav() {
+        binding.vpMain.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                binding.bottomNav.menu.getItem(if (position == 0) 0 else 2).isChecked = true
+            }
+        })
+
+        binding.bottomNav.setOnItemSelectedListener {
+            binding.vpMain.currentItem = when (it.itemId) {
+                R.id.menu_home -> 0
+                R.id.menu_my_page -> 1
+                else -> return@setOnItemSelectedListener false
+            }
+            return@setOnItemSelectedListener true
+        }
     }
 }

--- a/app/src/main/java/com/readme/android/MainActivity.kt
+++ b/app/src/main/java/com/readme/android/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.readme.android
 
 import android.os.Bundle
-import androidx.viewpager2.widget.ViewPager2
 import com.readme.android.adapter.MainViewPagerAdapter
 import com.readme.android.core.base.BindingActivity
 import com.readme.android.databinding.ActivityMainBinding
@@ -24,11 +23,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     }
 
     private fun syncVpWithBottomNav() {
-        binding.vpMain.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
-            override fun onPageSelected(position: Int) {
-                binding.bottomNav.menu.getItem(if (position == 0) 0 else 2).isChecked = true
-            }
-        })
+        binding.vpMain.isUserInputEnabled = false
 
         binding.bottomNav.setOnItemSelectedListener {
             when (it.itemId) {

--- a/app/src/main/java/com/readme/android/adapter/MainViewPagerAdapter.kt
+++ b/app/src/main/java/com/readme/android/adapter/MainViewPagerAdapter.kt
@@ -5,7 +5,12 @@ import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
 class MainViewPagerAdapter(fa: FragmentActivity) : FragmentStateAdapter(fa) {
-    val fragments = mutableListOf<Fragment>()
-    override fun getItemCount(): Int = fragments.size
-    override fun createFragment(position: Int): Fragment = fragments[position]
+    private val _fragmentList = mutableListOf<Fragment>()
+    var fragmentList: List<Fragment> = _fragmentList
+        set(value) {
+            _fragmentList.addAll(value)
+        }
+
+    override fun getItemCount(): Int = _fragmentList.size
+    override fun createFragment(position: Int): Fragment = _fragmentList[position]
 }

--- a/app/src/main/java/com/readme/android/adapter/MainViewPagerAdapter.kt
+++ b/app/src/main/java/com/readme/android/adapter/MainViewPagerAdapter.kt
@@ -1,0 +1,11 @@
+package com.readme.android.adapter
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class MainViewPagerAdapter(fa: FragmentActivity) : FragmentStateAdapter(fa) {
+    val fragments = mutableListOf<Fragment>()
+    override fun getItemCount(): Int = fragments.size
+    override fun createFragment(position: Int): Fragment = fragments[position]
+}

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -8,11 +8,11 @@
         android:icon="@drawable/ic_home"
         android:title="@string/home" />
 
-<!--    <item-->
-<!--        android:id="@+id/blank"-->
-<!--        android:enabled="false"-->
-<!--        android:title=""-->
-<!--        app:showAsAction="never" />-->
+    <item
+        android:id="@+id/blank"
+        android:enabled="false"
+        android:title=""
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/menu_my_page"

--- a/shared/src/main/res/values/themes.xml
+++ b/shared/src/main/res/values/themes.xml
@@ -10,7 +10,8 @@
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:statusBarColor">@color/white</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <!-- Customize your theme here. -->
         <item name="android:includeFontPadding">false</item>
         <item name="bottomSheetDialogTheme">@style/ReadmeBottomSheetDialogStyle</item>


### PR DESCRIPTION
## 관련 이슈번호
- closed #29

## 작업 설명
- 제곧내(이슈 참고 부탁드려요)
- viewpager 이동하는데 상단바 색깔이 아직 default 보라색인게 아주 킹받아서, fragment, activity 별로 상태바 색깔을 바꿔보려고 이런저런 짓을 많이 해봤습니다..

결론은 그냥 status bar 단색으로 넣자인데, 결론까지 다다른 과정은 아래에 슬랙 내용 복붙해두겠슴니다..!

- 지금은 **`임시로`** 그냥 white로 status bar 설정해 두었습니다!

- 참고로, 첫번째 커밋이 #27 을 참조하고 있는데 실수입니다. #29 입니다.

<details markdown="1">
<summary>김효림의 주저리주저리</summary>

To. 존경하는 디자이너 선생님들...
오늘도 개발자가 안된다고 말했다.. 그런거 시전하고 싶지않은데..
부탁드릴게 있어서 오늘도 이렇게 주저리주저리 글을 써봅니다..:울다::울다:
결론부터 말하자면 상단바 컬러를 고정하는게 좋을 것 같다는 의견을 전달하러 왔습니다.
아래는, 이 결론에 다다르게 된 과정에 대한 설명입니다.
현재 디자인 해주신 뷰를 보면 화면마다 상태바(시간, 와이파이, 배터리 뜨는 곳) 컬러가 뷰마다 다르게 지정되어 있습니다.
이럴 경우, 안드로이드에서는 상단바 컬러를 뷰마다 일일이 지정해주어야 합니다.
그러나 이렇게 상단바 컬러를 지정할 경우 home-mypage를 이동하는 부분에서 부자연스럽게 작동합니다. (아래 동영상 참고)
따라서, 이에 대한 차안으로 적용할 수 있는 방법이 상태바의 컬러를 transparent로 지정하고,
상태바의 영역까지 뷰를 확장시키는 방법입니다.
그러나 이 방법보다 상단바 색을 고정하는것이 더 나을것 같다고 생각하는데, 이에는 두 가지 근거가 있습니다.
Android System에서는 화면을 확장해서 status bar 영역에 놓는걸 권장하지 않는다
home과 Mypage의 스크롤 영역이 전체로 지정되어 있으므로(기디 요청사항),
      스크롤 시에 상태바 영역에 컨텐츠가 보이게 됩니다. 즉, 시계와 배터리 뒷쪽으로 컨텐츠가 겹쳐서 보이기 떄문에, 디자인적으로도 이쁘지 않을 것 같네요:울다:
따라서 안드로이드의 상태바의 컬러를 단색으로 지정하는게 좋을것 같다는 의견을 조심스레 전달 드립니다..!

</details>