### PR TITLE
[feat] Login / 네이버 로그인 로직 붙이기 (#58,61)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,17 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".READMEApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_readme_launcher"
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_readme_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Readme">
         <activity
             android:name=".auth.ui.LoginActivity"
-            android:exported="false" />
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <!-- leakcanary 안드로이드 12 부터 버전충돌 문제 해결 -->
         <activity-alias
             android:name="leakcanary.internal.activity.LeakLauncherActivity"
@@ -20,14 +28,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true"
-            android:theme="@style/Theme.App.Starting">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:exported="false"
+            android:theme="@style/Theme.App.Starting"/>
         <activity
             android:name=".main.ui.feed.FeedDetailActivity"
             android:exported="false" />

--- a/app/src/main/java/com/readme/android/di/LocalDataSourceModule.kt
+++ b/app/src/main/java/com/readme/android/di/LocalDataSourceModule.kt
@@ -1,0 +1,18 @@
+package com.readme.android.di
+
+import com.readme.android.data.local.datasource.LocalPreferenceUserDataSource
+import com.readme.android.data.local.datasource.LocalPreferenceUserDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface LocalDataSourceModule {
+
+    @Binds
+    @Singleton
+    fun bindsLocalPreferenceUserDataSource(source: LocalPreferenceUserDataSourceImpl): LocalPreferenceUserDataSource
+}

--- a/app/src/main/java/com/readme/android/di/LocalPreferencesModule.kt
+++ b/app/src/main/java/com/readme/android/di/LocalPreferencesModule.kt
@@ -1,0 +1,33 @@
+package com.readme.android.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import androidx.security.crypto.MasterKeys
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocalPreferencesModule {
+    @Provides
+    @Singleton
+    fun providesLocalPreferences(@ApplicationContext context: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(context,MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        return EncryptedSharedPreferences.create(
+            context,
+            "encryptedShared",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+}

--- a/app/src/main/java/com/readme/android/di/RemoteDataSourceModule.kt
+++ b/app/src/main/java/com/readme/android/di/RemoteDataSourceModule.kt
@@ -2,6 +2,8 @@ package com.readme.android.di
 
 import com.readme.android.data.remote.datasource.RemoteBookSearchDataSource
 import com.readme.android.data.remote.datasource.RemoteBookSearchDataSourceImpl
+import com.readme.android.data.remote.datasource.RemoteLoginDataSource
+import com.readme.android.data.remote.datasource.RemoteLoginDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +17,8 @@ interface RemoteDataSourceModule {
     @Binds
     @Singleton
     fun bindsRemoteBookSearchDataSource(source: RemoteBookSearchDataSourceImpl): RemoteBookSearchDataSource
+
+    @Binds
+    @Singleton
+    fun bindsRemoteLoginDataSource(source: RemoteLoginDataSourceImpl): RemoteLoginDataSource
 }

--- a/app/src/main/java/com/readme/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/readme/android/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.readme.android.di
 
 import com.readme.android.data.repository.BookSearchRepositoryImpl
+import com.readme.android.data.repository.LoginRepositoryImpl
 import com.readme.android.domain.repository.BookSearchRepository
+import com.readme.android.domain.repository.LoginRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +17,8 @@ interface RepositoryModule {
     @Binds
     @Singleton
     fun bindsBookSearchRepository(repository: BookSearchRepositoryImpl): BookSearchRepository
+
+    @Binds
+    @Singleton
+    fun bindsLoginRepository(repository: LoginRepositoryImpl): LoginRepository
 }

--- a/app/src/main/java/com/readme/android/di/RepositoryModule.kt
+++ b/app/src/main/java/com/readme/android/di/RepositoryModule.kt
@@ -1,6 +1,6 @@
 package com.readme.android.di
 
-import com.readme.android.data.remote.repository.BookSearchRepositoryImpl
+import com.readme.android.data.repository.BookSearchRepositoryImpl
 import com.readme.android.domain.repository.BookSearchRepository
 import dagger.Binds
 import dagger.Module

--- a/app/src/main/java/com/readme/android/di/RetrofitServiceModule.kt
+++ b/app/src/main/java/com/readme/android/di/RetrofitServiceModule.kt
@@ -1,7 +1,9 @@
 package com.readme.android.di
 
+import com.readme.android.data.remote.service.LoginService
 import com.readme.android.data.remote.service.NaverBookSearchService
 import com.readme.android.di.annotations.NaverBookSearchServer
+import com.readme.android.di.annotations.ReadMeServer
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,4 +20,8 @@ object RetrofitServiceModule {
     fun providesNaverBookSearchService(@NaverBookSearchServer retrofit: Retrofit): NaverBookSearchService =
         retrofit.create(NaverBookSearchService::class.java)
 
+    @Provides
+    @Singleton
+    fun providesLoginService(@ReadMeServer retrofit: Retrofit): LoginService =
+        retrofit.create(LoginService::class.java)
 }

--- a/app/src/main/java/com/readme/android/navigator/MainNavigatorImpl.kt
+++ b/app/src/main/java/com/readme/android/navigator/MainNavigatorImpl.kt
@@ -2,6 +2,7 @@ package com.readme.android.navigator
 
 import android.content.Context
 import com.readme.android.MainActivity
+import com.readme.android.auth.ui.LoginActivity
 import javax.inject.Inject
 import com.readme.android.core_ui.ext.startActivity
 import com.readme.android.set_nick_name.SetNickNameActivity
@@ -17,5 +18,9 @@ internal class MainNavigatorImpl @Inject constructor() : MainNavigator {
         platform: Pair<String, String>
     ) {
         context.startActivity<SetNickNameActivity>(socialToken,platform)
+    }
+
+    override fun openLogin(context: Context) {
+        context.startActivity<LoginActivity>()
     }
 }

--- a/app/src/main/java/com/readme/android/navigator/MainNavigatorImpl.kt
+++ b/app/src/main/java/com/readme/android/navigator/MainNavigatorImpl.kt
@@ -4,9 +4,18 @@ import android.content.Context
 import com.readme.android.MainActivity
 import javax.inject.Inject
 import com.readme.android.core_ui.ext.startActivity
+import com.readme.android.set_nick_name.SetNickNameActivity
 
 internal class MainNavigatorImpl @Inject constructor() : MainNavigator {
     override fun openMain(context: Context) {
         context.startActivity<MainActivity>()
+    }
+
+    override fun openSetNickName(
+        context: Context,
+        socialToken: Pair<String, String>,
+        platform: Pair<String, String>
+    ) {
+        context.startActivity<SetNickNameActivity>(socialToken,platform)
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -79,6 +79,7 @@ object ThirdPartyDependencies {
         "com.google.android.gms:play-services-oss-licenses:${Versions.ossVersion}"
     const val gson = "com.google.code.gson:gson:${Versions.gsonVersion}"
     const val gsonConverter = "com.squareup.retrofit2:converter-gson:${Versions.gsonConverterVersion}"
+    const val naverAuth = "com.navercorp.nid:oauth:${Versions.naverAuth}"
 }
 
 object FirebaseDependency {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -46,6 +46,7 @@ object Versions {
     const val kotlinxSerializationJsonVersion = "1.2.2"
     const val gsonVersion = "2.8.9"
     const val gsonConverterVersion = "2.9.0"
+    const val naverAuth = "5.1.0"
 
     val javaVersion = JavaVersion.VERSION_11
     const val jvmVersion = "11"

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 
 dependencies {
     implementation(project(":shared"))
+    implementation(project(":navigator"))
 
     implementation(ThirdPartyDependencies.timber)
 

--- a/core-ui/src/main/java/com/readme/android/core_ui/base/BaseViewModel.kt
+++ b/core-ui/src/main/java/com/readme/android/core_ui/base/BaseViewModel.kt
@@ -1,0 +1,23 @@
+package com.readme.android.core_ui.base
+
+import android.content.SharedPreferences
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.readme.android.core_ui.util.Event
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.android.qualifiers.ActivityContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+import java.security.cert.CertificateException
+
+abstract class  BaseViewModel : ViewModel() {
+
+    private val _moveToLogin = MutableLiveData<Event<Boolean>>()
+    val moveToLogin: LiveData<Event<Boolean>> = _moveToLogin
+
+    val exceptionHandler = CoroutineExceptionHandler{ _, throwable ->
+        when(throwable){
+            is CertificateException -> _moveToLogin.postValue(Event(true))
+        }
+    }
+}

--- a/core-ui/src/main/java/com/readme/android/core_ui/base/BindingActivity.kt
+++ b/core-ui/src/main/java/com/readme/android/core_ui/base/BindingActivity.kt
@@ -1,5 +1,6 @@
 package com.readme.android.core_ui.base
 
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.MotionEvent
 import android.widget.EditText
@@ -7,7 +8,12 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.ViewModel
 import com.readme.android.core_ui.ext.closeKeyboard
+import com.readme.android.core_ui.util.EventObserver
+import com.readme.android.core_ui.util.Injector
+import com.readme.android.navigator.MainNavigator
+import dagger.hilt.android.EntryPointAccessors
 
 abstract class BindingActivity<T : ViewDataBinding>(
     @LayoutRes private val layoutRes: Int
@@ -37,5 +43,28 @@ abstract class BindingActivity<T : ViewDataBinding>(
         }
 
         return super.dispatchTouchEvent(ev)
+    }
+
+    private val mainNavigator: MainNavigator by lazy {
+        EntryPointAccessors.fromActivity(
+            this,
+            Injector.MainNavigaterInjector::class.java
+        ).mainNavigator()
+    }
+
+    private val sharedPreferences: SharedPreferences by lazy {
+        EntryPointAccessors.fromActivity(
+            this,
+            Injector.SharedPreferencesInjector::class.java
+        ).sharedPreferences()
+    }
+
+    fun terminationTokenHandling (viewModel: BaseViewModel){
+        viewModel.moveToLogin.observe(this,EventObserver{
+            mainNavigator.openLogin(this)
+            sharedPreferences.edit().remove("READ_ME_ACCESS_TOKEN").apply()
+            sharedPreferences.edit().remove("USER_NICKNAME").apply()
+            finish()
+        })
     }
 }

--- a/core-ui/src/main/java/com/readme/android/core_ui/util/Event.kt
+++ b/core-ui/src/main/java/com/readme/android/core_ui/util/Event.kt
@@ -1,0 +1,17 @@
+package com.readme.android.core_ui.util
+
+open class Event<out T>(private val content: T) {
+    var hasBeenHandled = false
+        private set
+
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    fun peekContent(): T = content
+}

--- a/core-ui/src/main/java/com/readme/android/core_ui/util/EventObserver.kt
+++ b/core-ui/src/main/java/com/readme/android/core_ui/util/EventObserver.kt
@@ -1,0 +1,11 @@
+package com.readme.android.core_ui.util
+
+import androidx.lifecycle.Observer
+
+class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
+    override fun onChanged(event: Event<T>?) {
+        event?.getContentIfNotHandled()?.let { value ->
+            onEventUnhandledContent(value)
+        }
+    }
+}

--- a/core-ui/src/main/java/com/readme/android/core_ui/util/Injector.kt
+++ b/core-ui/src/main/java/com/readme/android/core_ui/util/Injector.kt
@@ -1,5 +1,7 @@
 package com.readme.android.core_ui.util
 
+import android.content.SharedPreferences
+import com.readme.android.navigator.MainNavigator
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
@@ -9,5 +11,17 @@ sealed interface Injector {
     @InstallIn(ActivityComponent::class)
     interface ResolutionMetricsInjector {
         fun resolutionMetrics(): ResolutionMetrics
+    }
+
+    @EntryPoint
+    @InstallIn(ActivityComponent::class)
+    interface MainNavigaterInjector {
+        fun mainNavigator(): MainNavigator
+    }
+
+    @EntryPoint
+    @InstallIn(ActivityComponent::class)
+    interface SharedPreferencesInjector {
+        fun sharedPreferences(): SharedPreferences
     }
 }

--- a/data/src/main/java/com/readme/android/data/local/datasource/LocalPreferenceUserDataSource.kt
+++ b/data/src/main/java/com/readme/android/data/local/datasource/LocalPreferenceUserDataSource.kt
@@ -1,0 +1,15 @@
+package com.readme.android.data.local.datasource
+
+interface LocalPreferenceUserDataSource {
+    fun getAccessToken(): String
+
+    fun saveAccessToken(accessToken: String)
+
+    fun saveUserNickname(userNickname: String)
+
+    fun getUserNickname(): String
+
+    fun removeAccessToken()
+
+    fun removeUserNickname()
+}

--- a/data/src/main/java/com/readme/android/data/local/datasource/LocalPreferenceUserDataSourceImpl.kt
+++ b/data/src/main/java/com/readme/android/data/local/datasource/LocalPreferenceUserDataSourceImpl.kt
@@ -1,0 +1,37 @@
+package com.readme.android.data.local.datasource
+
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class LocalPreferenceUserDataSourceImpl @Inject constructor(
+    private val localPreferences: SharedPreferences
+) : LocalPreferenceUserDataSource {
+    override fun getAccessToken(): String =
+        localPreferences.getString(READ_ME_ACCESS_TOKEN, "") ?: ""
+
+    override fun saveAccessToken(accessToken: String) {
+        localPreferences.edit().putString(READ_ME_ACCESS_TOKEN, accessToken).apply()
+    }
+
+    override fun getUserNickname(): String =
+        localPreferences.getString(USER_NICKNAME,"") ?: ""
+
+    override fun saveUserNickname(userNickname: String) {
+        localPreferences.edit().putString(USER_NICKNAME, userNickname).apply()
+    }
+
+    override fun removeAccessToken() {
+        localPreferences.edit().remove(READ_ME_ACCESS_TOKEN).apply()
+    }
+
+    override fun removeUserNickname() {
+        localPreferences.edit().remove(USER_NICKNAME).apply()
+    }
+
+
+    companion object {
+        const val READ_ME_ACCESS_TOKEN = "READ_ME_ACCESS_TOKEN"
+        const val USER_NICKNAME = "USER_NICKNAME"
+    }
+}
+

--- a/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSource.kt
+++ b/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSource.kt
@@ -7,5 +7,5 @@ import com.readme.android.data.remote.model.response.LoginResponse
 
 interface RemoteLoginDataSource {
 
-    suspend fun postNaverLogin(loginRequest: LoginRequest):NetworkState<BaseResponse<LoginResponse>>
+    suspend fun postLogin(loginRequest: LoginRequest):NetworkState<BaseResponse<LoginResponse>>
 }

--- a/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSource.kt
+++ b/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSource.kt
@@ -1,0 +1,11 @@
+package com.readme.android.data.remote.datasource
+
+import com.readme.android.data.remote.calladapter.NetworkState
+import com.readme.android.data.remote.model.request.LoginRequest
+import com.readme.android.data.remote.model.response.BaseResponse
+import com.readme.android.data.remote.model.response.LoginResponse
+
+interface RemoteLoginDataSource {
+
+    suspend fun postNaverLogin(loginRequest: LoginRequest):NetworkState<BaseResponse<LoginResponse>>
+}

--- a/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSourceImpl.kt
+++ b/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSourceImpl.kt
@@ -10,6 +10,6 @@ import javax.inject.Inject
 class RemoteLoginDataSourceImpl @Inject constructor(
     private val loginService: LoginService
 ) : RemoteLoginDataSource {
-    override suspend fun postNaverLogin(loginRequest: LoginRequest): NetworkState<BaseResponse<LoginResponse>> =
-        loginService.postNaverLogin(loginRequest)
+    override suspend fun postLogin(loginRequest: LoginRequest): NetworkState<BaseResponse<LoginResponse>> =
+        loginService.postLogin(loginRequest)
 }

--- a/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSourceImpl.kt
+++ b/data/src/main/java/com/readme/android/data/remote/datasource/RemoteLoginDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.readme.android.data.remote.datasource
+
+import com.readme.android.data.remote.calladapter.NetworkState
+import com.readme.android.data.remote.model.request.LoginRequest
+import com.readme.android.data.remote.model.response.BaseResponse
+import com.readme.android.data.remote.model.response.LoginResponse
+import com.readme.android.data.remote.service.LoginService
+import javax.inject.Inject
+
+class RemoteLoginDataSourceImpl @Inject constructor(
+    private val loginService: LoginService
+) : RemoteLoginDataSource {
+    override suspend fun postNaverLogin(loginRequest: LoginRequest): NetworkState<BaseResponse<LoginResponse>> =
+        loginService.postNaverLogin(loginRequest)
+}

--- a/data/src/main/java/com/readme/android/data/remote/model/request/LoginRequest.kt
+++ b/data/src/main/java/com/readme/android/data/remote/model/request/LoginRequest.kt
@@ -4,8 +4,9 @@ import com.google.gson.annotations.SerializedName
 import retrofit2.http.Multipart
 
 data class LoginRequest(
-    @SerializedName("platfrom")
+    @SerializedName("platform")
     val platform: String,
     @SerializedName("socialToken")
     val socialToken: String
 )
+

--- a/data/src/main/java/com/readme/android/data/remote/model/request/LoginRequest.kt
+++ b/data/src/main/java/com/readme/android/data/remote/model/request/LoginRequest.kt
@@ -1,0 +1,11 @@
+package com.readme.android.data.remote.model.request
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.http.Multipart
+
+data class LoginRequest(
+    @SerializedName("platfrom")
+    val platform: String,
+    @SerializedName("socialToken")
+    val socialToken: String
+)

--- a/data/src/main/java/com/readme/android/data/remote/model/response/BaseResponse.kt
+++ b/data/src/main/java/com/readme/android/data/remote/model/response/BaseResponse.kt
@@ -1,0 +1,15 @@
+package com.readme.android.data.remote.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class BaseResponse<T>(
+    @SerializedName("data")
+    val `data`: T,
+    @SerializedName("message")
+    val message: String,
+    @SerializedName("status")
+    val status: Int,
+    @SerializedName("success")
+    val success: Boolean
+)
+

--- a/data/src/main/java/com/readme/android/data/remote/model/response/LoginResponse.kt
+++ b/data/src/main/java/com/readme/android/data/remote/model/response/LoginResponse.kt
@@ -1,0 +1,14 @@
+package com.readme.android.data.remote.model.response
+
+
+import com.google.gson.annotations.SerializedName
+
+data class LoginResponse(
+    @SerializedName("accessToken")
+    val accessToken: String?,
+    @SerializedName("isNewUser")
+    val isNewUser: Boolean
+)
+
+
+

--- a/data/src/main/java/com/readme/android/data/remote/service/LoginService.kt
+++ b/data/src/main/java/com/readme/android/data/remote/service/LoginService.kt
@@ -10,7 +10,7 @@ import retrofit2.http.POST
 interface LoginService {
 
     @POST("user/login")
-    suspend fun postNaverLogin (
+    suspend fun postLogin (
         @Body body: LoginRequest
     ): NetworkState<BaseResponse<LoginResponse>>
 }

--- a/data/src/main/java/com/readme/android/data/remote/service/LoginService.kt
+++ b/data/src/main/java/com/readme/android/data/remote/service/LoginService.kt
@@ -1,0 +1,16 @@
+package com.readme.android.data.remote.service
+
+import com.readme.android.data.remote.calladapter.NetworkState
+import com.readme.android.data.remote.model.request.LoginRequest
+import com.readme.android.data.remote.model.response.BaseResponse
+import com.readme.android.data.remote.model.response.LoginResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface LoginService {
+
+    @POST("user/login")
+    suspend fun postNaverLogin (
+        @Body body: LoginRequest
+    ): NetworkState<BaseResponse<LoginResponse>>
+}

--- a/data/src/main/java/com/readme/android/data/repository/BookSearchRepositoryImpl.kt
+++ b/data/src/main/java/com/readme/android/data/repository/BookSearchRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package com.readme.android.data.remote.repository
+package com.readme.android.data.repository
 
 import com.readme.android.core_data.exception.RetrofitFailureStateException
 import com.readme.android.data.remote.calladapter.NetworkState

--- a/data/src/main/java/com/readme/android/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/readme/android/data/repository/LoginRepositoryImpl.kt
@@ -1,0 +1,69 @@
+package com.readme.android.data.repository
+
+import com.readme.android.core_data.exception.RetrofitFailureStateException
+import com.readme.android.data.local.datasource.LocalPreferenceUserDataSource
+import com.readme.android.data.remote.calladapter.NetworkState
+import com.readme.android.data.remote.datasource.RemoteLoginDataSource
+import com.readme.android.data.remote.model.request.LoginRequest
+import com.readme.android.domain.entity.request.DomainLoginRequest
+import com.readme.android.domain.entity.response.DomainLoginResponse
+import com.readme.android.domain.repository.LoginRepository
+import timber.log.Timber
+import javax.inject.Inject
+import kotlin.math.log
+
+class LoginRepositoryImpl @Inject constructor(
+    private val localPreferenceUserDataSource: LocalPreferenceUserDataSource,
+    private val remoteLoginDataSource: RemoteLoginDataSource
+) : LoginRepository {
+    override fun getAccessToken(): String =
+        localPreferenceUserDataSource.getAccessToken()
+
+    override fun saveAccessToken(accessToken: String) {
+        localPreferenceUserDataSource.saveAccessToken(accessToken)
+    }
+
+    override fun getUserNickname(): String =
+        localPreferenceUserDataSource.getUserNickname()
+
+    override fun saveUserNickname(userNickname: String) {
+        localPreferenceUserDataSource.saveUserNickname(userNickname)
+    }
+
+    override fun removeAccessToken() {
+        localPreferenceUserDataSource.removeAccessToken()
+    }
+
+    override fun removeUserNickname() {
+        localPreferenceUserDataSource.removeUserNickname()
+    }
+
+    override suspend fun postNaverLogin(loginRequest: DomainLoginRequest): Result<DomainLoginResponse> {
+        val response = remoteLoginDataSource.postNaverLogin(
+            LoginRequest(
+                platform = loginRequest.platform,
+                socialToken = loginRequest.socialToken
+            )
+        )
+
+        when (response) {
+            is NetworkState.Success -> return Result.success(
+                DomainLoginResponse(
+                    accessToken = response.body.data.accessToken,
+                    isNewUser = response.body.data.isNewUser
+                )
+            )
+            is NetworkState.Failure -> return Result.failure(
+                RetrofitFailureStateException(
+                    response.error,
+                    response.code
+                )
+            )
+            is NetworkState.NetworkError -> Timber.tag("${this.javaClass.name}_postNaverLogin")
+                .d(response.error)
+            is NetworkState.UnknownError -> Timber.tag("${this.javaClass.name}_postNaverLogin")
+                .d(response.t)
+        }
+        return Result.failure(IllegalStateException("NetworkError or UnKnownError please check timber"))
+    }
+}

--- a/data/src/main/java/com/readme/android/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/readme/android/data/repository/LoginRepositoryImpl.kt
@@ -10,7 +10,6 @@ import com.readme.android.domain.entity.response.DomainLoginResponse
 import com.readme.android.domain.repository.LoginRepository
 import timber.log.Timber
 import javax.inject.Inject
-import kotlin.math.log
 
 class LoginRepositoryImpl @Inject constructor(
     private val localPreferenceUserDataSource: LocalPreferenceUserDataSource,
@@ -38,8 +37,8 @@ class LoginRepositoryImpl @Inject constructor(
         localPreferenceUserDataSource.removeUserNickname()
     }
 
-    override suspend fun postNaverLogin(loginRequest: DomainLoginRequest): Result<DomainLoginResponse> {
-        val response = remoteLoginDataSource.postNaverLogin(
+    override suspend fun postLogin(loginRequest: DomainLoginRequest): Result<DomainLoginResponse> {
+        val response = remoteLoginDataSource.postLogin(
             LoginRequest(
                 platform = loginRequest.platform,
                 socialToken = loginRequest.socialToken

--- a/domain/src/main/java/com/readme/android/domain/entity/request/DomainLoginRequest.kt
+++ b/domain/src/main/java/com/readme/android/domain/entity/request/DomainLoginRequest.kt
@@ -1,0 +1,6 @@
+package com.readme.android.domain.entity.request
+
+data class DomainLoginRequest(
+    val platform: String,
+    val socialToken: String
+)

--- a/domain/src/main/java/com/readme/android/domain/entity/response/DomainLoginResponse.kt
+++ b/domain/src/main/java/com/readme/android/domain/entity/response/DomainLoginResponse.kt
@@ -1,0 +1,6 @@
+package com.readme.android.domain.entity.response
+
+data class DomainLoginResponse(
+    val accessToken: String?,
+    val isNewUser: Boolean
+)

--- a/domain/src/main/java/com/readme/android/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/readme/android/domain/repository/LoginRepository.kt
@@ -17,5 +17,5 @@ interface LoginRepository {
 
     fun removeUserNickname()
 
-    suspend fun postNaverLogin(loginRequest: DomainLoginRequest):Result<DomainLoginResponse>
+    suspend fun postLogin(loginRequest: DomainLoginRequest):Result<DomainLoginResponse>
 }

--- a/domain/src/main/java/com/readme/android/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/readme/android/domain/repository/LoginRepository.kt
@@ -1,0 +1,21 @@
+package com.readme.android.domain.repository
+
+import com.readme.android.domain.entity.request.DomainLoginRequest
+import com.readme.android.domain.entity.response.DomainLoginResponse
+
+interface LoginRepository {
+
+    fun getAccessToken(): String
+
+    fun saveAccessToken(accessToken: String)
+
+    fun saveUserNickname(userNickname: String)
+
+    fun getUserNickname(): String
+
+    fun removeAccessToken()
+
+    fun removeUserNickname()
+
+    suspend fun postNaverLogin(loginRequest: DomainLoginRequest):Result<DomainLoginResponse>
+}

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":shared"))
     implementation(project(":navigator"))
+    implementation(project(":core-data"))
 
     // Android Core
     implementation(AndroidXDependencies.coreKtx)

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -1,3 +1,8 @@
+import org.jetbrains.kotlin.konan.properties.Properties
+
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
+
 plugins {
     id("com.android.library")
     kotlin("android")
@@ -8,6 +13,10 @@ plugins {
 android {
     buildFeatures {
         dataBinding = true
+    }
+    defaultConfig {
+        buildConfigField("String","X_NAVER_CLIENT_ID",properties.getProperty("X_NAVER_CLIENT_ID"))
+        buildConfigField("String","X_NAVER_CLIENT_SECRET",properties.getProperty("X_NAVER_CLIENT_SECRET"))
     }
     namespace = "com.readme.android.auth"
 }
@@ -37,4 +46,7 @@ dependencies {
 
     // Logger - Timber
     implementation(ThirdPartyDependencies.timber)
+
+    // Naver - social Login
+    implementation(ThirdPartyDependencies.naverAuth)
 }

--- a/feature/auth/src/main/AndroidManifest.xml
+++ b/feature/auth/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.readme.android.auth">
+    <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
@@ -1,6 +1,11 @@
 package com.readme.android.auth.ui
 
 import android.os.Bundle
+import androidx.activity.viewModels
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.OAuthLoginCallback
+import com.readme.android.auth.BuildConfig.X_NAVER_CLIENT_ID
+import com.readme.android.auth.BuildConfig.X_NAVER_CLIENT_SECRET
 import com.readme.android.auth.R
 import com.readme.android.auth.databinding.ActivityLoginBinding
 import com.readme.android.core_ui.base.BindingActivity
@@ -12,6 +17,7 @@ import javax.inject.Inject
 class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_login) {
     @Inject
     lateinit var mainNavigator: MainNavigator
+    private val loginViewModel by viewModels<LoginViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,8 +32,10 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
             }
 
             layoutNaver.setOnClickListener {
-                // TODO : 소셜로그인 네이버
-                moveMainActivity()
+                loginViewModel.setOAuthLoginCallback()
+                NaverIdLoginSDK.initialize(this@LoginActivity,X_NAVER_CLIENT_ID,X_NAVER_CLIENT_SECRET,"ReadMe")
+                NaverIdLoginSDK.authenticate(this@LoginActivity,loginViewModel.oAuthLoginCallback)
+//                moveMainActivity()
             }
         }
     }

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
@@ -24,8 +24,8 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initClickEvent()
-        initNaverLoginObserver()
-        initNaverLoginFaulureMessageObserver()
+        initLoginObserver()
+        initLoginFailureMessageObserver()
         initMoveToHomeObserver()
         initMoveToSetNickNameObserver()
         activeNaverbtnClickable()
@@ -35,11 +35,12 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         with(binding) {
             layoutKakao.setOnClickListener {
                 // TODO : 소셜로그인 카카오
-                moveMainActivity()
+                loginViewModel.updatePlatform(KAKAO)
             }
 
             layoutNaver.setOnClickListener {
                 it.isClickable = false
+                loginViewModel.updatePlatform(NAVER)
                 loginViewModel.naverSetOAuthLoginCallback()
                 NaverIdLoginSDK.initialize(
                     this@LoginActivity,
@@ -52,14 +53,14 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
         }
     }
 
-    private fun initNaverLoginObserver() {
+    private fun initLoginObserver() {
         loginViewModel.socialToken.observe(this) {
-            loginViewModel.postNaverLogin()
+            loginViewModel.postLogin()
         }
     }
 
-    private fun initNaverLoginFaulureMessageObserver() {
-        loginViewModel.naverLoginFailureMessage.observe(this) {
+    private fun initLoginFailureMessageObserver() {
+        loginViewModel.loginFailureMessage.observe(this) {
             Toast.makeText(this, "로그인에 실패 하였습니다", Toast.LENGTH_SHORT).show()
         }
     }
@@ -92,5 +93,10 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
 
     private fun activeNaverbtnClickable(){
         binding.layoutNaver.isClickable = true
+    }
+
+    companion object {
+        private const val NAVER = "NAVER"
+        private const val KAKAO = "KAKAO"
     }
 }

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
@@ -40,7 +40,6 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
 
             layoutNaver.setOnClickListener {
                 it.isClickable = false
-                moveSetNickNameActivity("NAVER","asd")
                 loginViewModel.naverSetOAuthLoginCallback()
                 NaverIdLoginSDK.initialize(
                     this@LoginActivity,

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginActivity.kt
@@ -1,6 +1,7 @@
 package com.readme.android.auth.ui
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.viewModels
 import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.OAuthLoginCallback
@@ -9,6 +10,7 @@ import com.readme.android.auth.BuildConfig.X_NAVER_CLIENT_SECRET
 import com.readme.android.auth.R
 import com.readme.android.auth.databinding.ActivityLoginBinding
 import com.readme.android.core_ui.base.BindingActivity
+import com.readme.android.core_ui.util.EventObserver
 import com.readme.android.navigator.MainNavigator
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -22,6 +24,11 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initClickEvent()
+        initNaverLoginObserver()
+        initNaverLoginFaulureMessageObserver()
+        initMoveToHomeObserver()
+        initMoveToSetNickNameObserver()
+        activeNaverbtnClickable()
     }
 
     private fun initClickEvent() {
@@ -32,16 +39,59 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
             }
 
             layoutNaver.setOnClickListener {
-                loginViewModel.setOAuthLoginCallback()
-                NaverIdLoginSDK.initialize(this@LoginActivity,X_NAVER_CLIENT_ID,X_NAVER_CLIENT_SECRET,"ReadMe")
-                NaverIdLoginSDK.authenticate(this@LoginActivity,loginViewModel.oAuthLoginCallback)
-//                moveMainActivity()
+                it.isClickable = false
+                moveSetNickNameActivity("NAVER","asd")
+                loginViewModel.naverSetOAuthLoginCallback()
+                NaverIdLoginSDK.initialize(
+                    this@LoginActivity,
+                    X_NAVER_CLIENT_ID,
+                    X_NAVER_CLIENT_SECRET,
+                    "ReadMe"
+                )
+                NaverIdLoginSDK.authenticate(this@LoginActivity, loginViewModel.oAuthLoginCallback)
             }
         }
+    }
+
+    private fun initNaverLoginObserver() {
+        loginViewModel.socialToken.observe(this) {
+            loginViewModel.postNaverLogin()
+        }
+    }
+
+    private fun initNaverLoginFaulureMessageObserver() {
+        loginViewModel.naverLoginFailureMessage.observe(this) {
+            Toast.makeText(this, "로그인에 실패 하였습니다", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun initMoveToSetNickNameObserver() {
+        loginViewModel.moveToSetNickname.observe(this, EventObserver {
+            moveSetNickNameActivity(it, loginViewModel.socialToken.value ?: "")
+        })
+    }
+
+    private fun initMoveToHomeObserver() {
+        loginViewModel.moveToHome.observe(this, EventObserver {
+            moveMainActivity()
+        })
     }
 
     private fun moveMainActivity() {
         mainNavigator.openMain(this)
         finish()
+    }
+
+    private fun moveSetNickNameActivity(platform: String, socialToken: String) {
+        mainNavigator.openSetNickName(
+            context = this,
+            platform = Pair("platform", platform),
+            socialToken = Pair("socialToken", socialToken)
+        )
+        finish()
+    }
+
+    private fun activeNaverbtnClickable(){
+        binding.layoutNaver.isClickable = true
     }
 }

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
@@ -45,7 +45,6 @@ class LoginViewModel @Inject constructor(
         oAuthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
                 _socialToken.postValue(NaverIdLoginSDK.getAccessToken())
-//                Log.d("토큰내놔",NaverIdLoginSDK.getAccessToken() ?: "") 은지용
                 NidOAuthLogin().callProfileApi(object : NidProfileCallback<NidProfileResponse> {
                     override fun onSuccess(result: NidProfileResponse) {
 //                        이제 이름 등등 받아서 어따 넘기는 로직

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
@@ -1,6 +1,5 @@
 package com.readme.android.auth.ui
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -10,14 +9,10 @@ import com.navercorp.nid.oauth.NidOAuthLogin
 import com.navercorp.nid.oauth.OAuthLoginCallback
 import com.navercorp.nid.profile.NidProfileCallback
 import com.navercorp.nid.profile.data.NidProfileResponse
-import com.readme.android.core_data.exception.RetrofitFailureStateException
 import com.readme.android.core_ui.util.Event
 import com.readme.android.domain.entity.request.DomainLoginRequest
-import com.readme.android.domain.entity.response.DomainLoginResponse
 import com.readme.android.domain.repository.LoginRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
@@ -72,7 +67,7 @@ class LoginViewModel @Inject constructor(
 
     fun postNaverLogin() {
         viewModelScope.launch {
-            loginRepository.postNaverLogin(
+            loginRepository.postLogin(
                 DomainLoginRequest(
                     platform = NAVER,
                     socialToken = socialToken.value ?: ""

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
@@ -1,52 +1,102 @@
 package com.readme.android.auth.ui
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.navercorp.nid.NaverIdLoginSDK
 import com.navercorp.nid.oauth.NidOAuthLogin
 import com.navercorp.nid.oauth.OAuthLoginCallback
 import com.navercorp.nid.profile.NidProfileCallback
 import com.navercorp.nid.profile.data.NidProfileResponse
+import com.readme.android.core_data.exception.RetrofitFailureStateException
+import com.readme.android.core_ui.util.Event
+import com.readme.android.domain.entity.request.DomainLoginRequest
+import com.readme.android.domain.entity.response.DomainLoginResponse
+import com.readme.android.domain.repository.LoginRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-
+    private val loginRepository: LoginRepository
 ) : ViewModel() {
-
     lateinit var oAuthLoginCallback: OAuthLoginCallback
         private set
 
-    fun setOAuthLoginCallback() {
+    private val _socialToken = MutableLiveData<String>()
+    val socialToken: LiveData<String> = _socialToken
+
+    private val _moveToSetNickname = MutableLiveData<Event<String>>()
+    val moveToSetNickname: LiveData<Event<String>> = _moveToSetNickname
+
+    private val _moveToHome = MutableLiveData<Event<Boolean>>()
+    val moveToHome: LiveData<Event<Boolean>> = _moveToHome
+
+    private val _naverLoginFailureMessage = MutableLiveData<String>()
+    val naverLoginFailureMessage: LiveData<String> = _naverLoginFailureMessage
+
+    fun naverSetOAuthLoginCallback() {
         oAuthLoginCallback = object : OAuthLoginCallback {
             override fun onSuccess() {
-                Log.d("이창환","${NaverIdLoginSDK.getAccessToken()}")
-
-                NidOAuthLogin().callProfileApi(object :NidProfileCallback<NidProfileResponse>{
+                _socialToken.postValue(NaverIdLoginSDK.getAccessToken())
+//                Log.d("토큰내놔",NaverIdLoginSDK.getAccessToken() ?: "") 은지용
+                NidOAuthLogin().callProfileApi(object : NidProfileCallback<NidProfileResponse> {
                     override fun onSuccess(result: NidProfileResponse) {
-//                        TODO("Not yet implemented")
+//                        이제 이름 등등 받아서 어따 넘기는 로직
                     }
 
                     override fun onError(errorCode: Int, message: String) {
-//                        TODO("Not yet implemented")
+                        Timber.d("$message NidProfileCallback 부분에서의 오류 onError")
                     }
 
                     override fun onFailure(httpStatus: Int, message: String) {
-//                        TODO("Not yet implemented")
+                        Timber.d("$message NidProfileCallback 부분에서의 오류 onFailure")
                     }
                 })
             }
 
             override fun onError(errorCode: Int, message: String) {
-//                TODO("Not yet implemented")
+                Timber.d("$message OAuthLoginCallback 부분에서의 오류 onError")
             }
 
             override fun onFailure(httpStatus: Int, message: String) {
-//                TODO("Not yet implemented")
+                Timber.d("$message OAuthLoginCallback 부분에서의 오류 onFailure")
             }
         }
     }
 
+    fun postNaverLogin() {
+        viewModelScope.launch {
+            loginRepository.postNaverLogin(
+                DomainLoginRequest(
+                    platform = NAVER,
+                    socialToken = socialToken.value ?: ""
+                )
+            ).onSuccess {
+                if (it.isNewUser) {
+                    _moveToSetNickname.postValue(Event(NAVER))
+                } else {
+                    saveAccessToken(it.accessToken ?: "")
+                    _moveToHome.postValue(Event(true))
+                }
+            }.onFailure {
+                _naverLoginFailureMessage.postValue(it.message)
+            }
+        }
+    }
 
+    fun saveAccessToken(accessToken: String) {
+        loginRepository.saveAccessToken(accessToken)
+    }
+
+    companion object {
+        private const val NAVER = "NAVER"
+        private const val KAKAO = "KAKAO"
+    }
 }

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
@@ -27,14 +27,17 @@ class LoginViewModel @Inject constructor(
     private val _socialToken = MutableLiveData<String>()
     val socialToken: LiveData<String> = _socialToken
 
+    private lateinit var platform :String
+
+
     private val _moveToSetNickname = MutableLiveData<Event<String>>()
     val moveToSetNickname: LiveData<Event<String>> = _moveToSetNickname
 
     private val _moveToHome = MutableLiveData<Event<Boolean>>()
     val moveToHome: LiveData<Event<Boolean>> = _moveToHome
 
-    private val _naverLoginFailureMessage = MutableLiveData<String>()
-    val naverLoginFailureMessage: LiveData<String> = _naverLoginFailureMessage
+    private val _loginFailureMessage = MutableLiveData<String>()
+    val loginFailureMessage: LiveData<String> = _loginFailureMessage
 
     fun naverSetOAuthLoginCallback() {
         oAuthLoginCallback = object : OAuthLoginCallback {
@@ -65,22 +68,22 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    fun postNaverLogin() {
+    fun postLogin() {
         viewModelScope.launch {
             loginRepository.postLogin(
                 DomainLoginRequest(
-                    platform = NAVER,
+                    platform = platform,
                     socialToken = socialToken.value ?: ""
                 )
             ).onSuccess {
                 if (it.isNewUser) {
-                    _moveToSetNickname.postValue(Event(NAVER))
+                    _moveToSetNickname.postValue(Event(platform))
                 } else {
                     saveAccessToken(it.accessToken ?: "")
                     _moveToHome.postValue(Event(true))
                 }
             }.onFailure {
-                _naverLoginFailureMessage.postValue(it.message)
+                _loginFailureMessage.postValue(it.message)
             }
         }
     }
@@ -89,8 +92,7 @@ class LoginViewModel @Inject constructor(
         loginRepository.saveAccessToken(accessToken)
     }
 
-    companion object {
-        private const val NAVER = "NAVER"
-        private const val KAKAO = "KAKAO"
+    fun updatePlatform(platform: String) {
+       this.platform = platform
     }
 }

--- a/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/readme/android/auth/ui/LoginViewModel.kt
@@ -1,0 +1,52 @@
+package com.readme.android.auth.ui
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.navercorp.nid.NaverIdLoginSDK
+import com.navercorp.nid.oauth.NidOAuthLogin
+import com.navercorp.nid.oauth.OAuthLoginCallback
+import com.navercorp.nid.profile.NidProfileCallback
+import com.navercorp.nid.profile.data.NidProfileResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+
+) : ViewModel() {
+
+    lateinit var oAuthLoginCallback: OAuthLoginCallback
+        private set
+
+    fun setOAuthLoginCallback() {
+        oAuthLoginCallback = object : OAuthLoginCallback {
+            override fun onSuccess() {
+                Log.d("이창환","${NaverIdLoginSDK.getAccessToken()}")
+
+                NidOAuthLogin().callProfileApi(object :NidProfileCallback<NidProfileResponse>{
+                    override fun onSuccess(result: NidProfileResponse) {
+//                        TODO("Not yet implemented")
+                    }
+
+                    override fun onError(errorCode: Int, message: String) {
+//                        TODO("Not yet implemented")
+                    }
+
+                    override fun onFailure(httpStatus: Int, message: String) {
+//                        TODO("Not yet implemented")
+                    }
+                })
+            }
+
+            override fun onError(errorCode: Int, message: String) {
+//                TODO("Not yet implemented")
+            }
+
+            override fun onFailure(httpStatus: Int, message: String) {
+//                TODO("Not yet implemented")
+            }
+        }
+    }
+
+
+}

--- a/feature/set-nick-name/src/main/java/com/readme/android/set_nick_name/SetNickNameActivity.kt
+++ b/feature/set-nick-name/src/main/java/com/readme/android/set_nick_name/SetNickNameActivity.kt
@@ -13,9 +13,10 @@ import com.readme.android.core_ui.constant.HAS_NO_STATE
 import com.readme.android.core_ui.constant.NO_SPECIAL_CHARACTER
 import com.readme.android.core_ui.constant.OVER_TEXT_LIMIT
 import com.readme.android.set_nick_name.databinding.ActivitySetNickNameBinding
+import dagger.hilt.android.AndroidEntryPoint
 import java.util.regex.Pattern
 
-
+@AndroidEntryPoint
 class SetNickNameActivity :
     BindingActivity<ActivitySetNickNameBinding>(R.layout.activity_set_nick_name) {
 

--- a/feature/set-nick-name/src/main/java/com/readme/android/set_nick_name/SetNickNameViewModel.kt
+++ b/feature/set-nick-name/src/main/java/com/readme/android/set_nick_name/SetNickNameViewModel.kt
@@ -3,8 +3,10 @@ package com.readme.android.set_nick_name
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
+@HiltViewModel
 class SetNickNameViewModel @Inject constructor(
 
 ) : ViewModel() {

--- a/navigator/src/main/java/com/readme/android/navigator/Navigator.kt
+++ b/navigator/src/main/java/com/readme/android/navigator/Navigator.kt
@@ -12,4 +12,7 @@ interface MainNavigator {
         socialToken: Pair<String, String>,
         platform: Pair<String, String>
     )
+
+    /** LoginActivity로 이동 */
+    fun openLogin(context: Context)
 }

--- a/navigator/src/main/java/com/readme/android/navigator/Navigator.kt
+++ b/navigator/src/main/java/com/readme/android/navigator/Navigator.kt
@@ -5,4 +5,11 @@ import android.content.Context
 interface MainNavigator {
     /** MainActivity로 이동 */
     fun openMain(context: Context)
+
+    /** SetNickNameActivity로 이동 */
+    fun openSetNickName(
+        context: Context,
+        socialToken: Pair<String, String>,
+        platform: Pair<String, String>
+    )
 }


### PR DESCRIPTION
## 관련 이슈번호
- closed #58 
- closed #61 

## 작업 설명
- 네이버 로그인 및 mainNavigation 을 통한 화면이동 설정
- 토큰 만료시 로그인 화면으로 이동하는 로직 coroutineExceptionHandler를 통해 처리(BaseViewModel,BindingActivity를 참고)-> 아직 로직을 테스트 해보지는 못함 (토큰이 붙는 api 를 못붙여서 붙으면 바로 테스트해보고 수정할예정)

카카오와 같이 쓸수있도록 로직 고민하고짬 카카오에서 소셜토큰 받아와서 넘기기만 되게 만들어놓음
카카오 버튼 클릭시 소셜토큰받아와서 LoginViewModel에 있는 socialToken 에 값만 넣어주됨(혹시 재사용하다가 이상한거 나오면 말해주면 같이 고쳐봅시다 처음에 무지성으로 네이버용으로만 만들었다가 나중에 네이버 걷어낸거라 카카오넣었을때 혹시나 오류날수있음 근데 아마안날꺼임)
