### PR TITLE
[chore] mypage_setting / 이용약관 -> 개인정보처리방침으로 링크 변경 (#137)

### DIFF
--- a/feature/main/src/main/java/com/readme/android/main/ui/mypage/MyPageSettingActivity.kt
+++ b/feature/main/src/main/java/com/readme/android/main/ui/mypage/MyPageSettingActivity.kt
@@ -44,7 +44,7 @@ class MyPageSettingActivity :
             }
 
             tvSeeTerms.setOnClickListener {
-                startUri("https://paint-red-74c.notion.site/e187f3913b914e869cf48c9bf10fc751")
+                startUri("https://www.notion.so/1c67563a635e4a129de4d32bc32a62d2")
             }
 
             tvLogout.setOnClickListener {


### PR DESCRIPTION
## 관련 이슈번호
- closed #137

## 작업 설명
- 안드로이드 1차 출시 후 개인정보 처리방침 관련해서 리젝먹음
- 환경설정의 이용약관 링크를 개인정보처리방침으로 링크 변경

## 작업화면

<img width="300" src="https://user-images.githubusercontent.com/59546818/192786711-9b9ce8b7-1d90-423e-bf65-6c3bdef8d428.png">


